### PR TITLE
Mention that the builds list is now paginated

### DIFF
--- a/builds/get-list.adoc
+++ b/builds/get-list.adoc
@@ -67,10 +67,10 @@
 [.definition.placeholder]
 Placeholder for the definition; auto-generated from JSON above.
 
-Use this method to list the most recent builds for the specified app.
-The number of results are limited to the 5 most recent builds by
-default, but you can request up to 100 builds using the `limit` query
-parameter.
+This method is paginated. By default, 10 items are returned in the
+response. You can request up to 100 items at a time using the `limit`
+query parameter.
+
 
 You can apply optional filters to the query:
 

--- a/builds/get-list.adoc
+++ b/builds/get-list.adoc
@@ -51,7 +51,7 @@
         "name": "limit",
         "type": "integer",
         "desc":   "Number of builds to list: min=1, max=100",
-        "def":  "5",
+        "def":  "10",
         "req":  false,
         "cue":  "Enter the number of builds to list"
       }


### PR DESCRIPTION
(Not ready to merge right away, we need to deploy the change first.)

I basically took the same wording than what we have for feedbacks. I noticed we don't mention the `link` header there so I didn't do it here either.

